### PR TITLE
Write control fix

### DIFF
--- a/client_server_test.go
+++ b/client_server_test.go
@@ -44,12 +44,20 @@ var cstDialer = Dialer{
 	HandshakeTimeout: 30 * time.Second,
 }
 
-type cstHandler struct{ *testing.T }
+type cstHandler struct {
+	*testing.T
+	s *cstServer
+}
 
 type cstServer struct {
 	*httptest.Server
 	URL string
 	t   *testing.T
+
+	waitForClientClose bool
+	sendClose          bool
+	sendCloseWC        bool
+	doClose            bool
 }
 
 const (
@@ -60,7 +68,7 @@ const (
 
 func newServer(t *testing.T) *cstServer {
 	var s cstServer
-	s.Server = httptest.NewServer(cstHandler{t})
+	s.Server = httptest.NewServer(cstHandler{t, &s})
 	s.Server.URL += cstRequestURI
 	s.URL = makeWsProto(s.Server.URL)
 	return &s
@@ -68,7 +76,7 @@ func newServer(t *testing.T) *cstServer {
 
 func newTLSServer(t *testing.T) *cstServer {
 	var s cstServer
-	s.Server = httptest.NewTLSServer(cstHandler{t})
+	s.Server = httptest.NewTLSServer(cstHandler{t, &s})
 	s.Server.URL += cstRequestURI
 	s.URL = makeWsProto(s.Server.URL)
 	return &s
@@ -103,23 +111,48 @@ func (t cstHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ws.Close()
 		return
 	}
-	op, rd, err := ws.NextReader()
-	if err != nil {
-		t.Logf("NextReader: %v", err)
-		return
+	for true {
+		// echo a message back to the client
+		op, rd, err := ws.NextReader()
+		if err != nil {
+			t.Logf("NextReader: %v", err)
+			return
+		}
+		wr, err := ws.NextWriter(op)
+		if err != nil {
+			t.Logf("NextWriter: %v", err)
+			return
+		}
+		if _, err = io.Copy(wr, rd); err != nil {
+			t.Logf("NextWriter: %v", err)
+			return
+		}
+		if err := wr.Close(); err != nil {
+			t.Logf("Close: %v", err)
+			return
+		}
+		t.Log("sent message")
+		if !t.s.waitForClientClose {
+			break
+		}
 	}
-	wr, err := ws.NextWriter(op)
-	if err != nil {
-		t.Logf("NextWriter: %v", err)
-		return
+	if t.s.sendClose {
+		err = ws.WriteMessage(CloseMessage, FormatCloseMessage(CloseNormalClosure, ""))
+		if err != nil {
+			t.Logf("WriteMessage(CloseMessage): %v", err)
+			return
+		}
+		t.Log("sent close")
+	} else if t.s.sendCloseWC {
+		err = ws.WriteControl(CloseMessage, FormatCloseMessage(CloseNormalClosure, ""), time.Now().Add(5*time.Second))
+		if err != nil {
+			t.Logf("WriteControl(CloseMessage): %v", err)
+			return
+		}
+		t.Log("sent close")
 	}
-	if _, err = io.Copy(wr, rd); err != nil {
-		t.Logf("NextWriter: %v", err)
-		return
-	}
-	if err := wr.Close(); err != nil {
-		t.Logf("Close: %v", err)
-		return
+	if t.s.doClose {
+		ws.Close()
 	}
 }
 
@@ -138,7 +171,8 @@ func sendRecv(t *testing.T, ws *Conn) {
 	if err := ws.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
 		t.Fatalf("SetReadDeadline: %v", err)
 	}
-	ws.Unsafe = true
+	ws.SetReadLimit(1000)
+	//ws.Unsafe = true
 	_, p, err := ws.ReadMessage()
 	if err != nil {
 		t.Fatalf("ReadMessage: %v", err)
@@ -903,4 +937,47 @@ func TestEmptyTracingDialWithContext(t *testing.T) {
 
 	defer ws.Close()
 	sendRecv(t, ws)
+}
+
+func TestServerCloseMessage(t *testing.T) {
+	s := newServer(t)
+	s.sendClose = true
+	testServerClose(t, s)
+}
+
+func TestServerCloseControl(t *testing.T) {
+	s := newServer(t)
+	s.sendCloseWC = true
+	testServerClose(t, s)
+}
+func testServerClose(t *testing.T, s *cstServer) {
+	s.doClose = true
+	defer s.Close()
+
+	ws, _, err := cstDialer.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+	ws.SetReadLimit(1000)
+	ws.SetReadDeadline(time.Now().Add(10 * time.Second))
+	sendRecv(t, ws)
+	msg := "blah blah blah"
+	err = ws.WriteMessage(TextMessage, []byte(msg))
+	if err != nil {
+		t.Fatalf("second write message: %v", err)
+	}
+	if err := ws.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	_, _, err = ws.ReadMessage()
+	switch err.(type) {
+	case nil:
+		// ok
+		t.Fatalf("ReadMessage: should have been closed")
+	case *CloseError:
+		// ok
+	default:
+		t.Fatalf("ReadMessage: %v", err)
+	}
 }

--- a/conn.go
+++ b/conn.go
@@ -376,14 +376,24 @@ func (c *Conn) CloseWithoutFlush() error {
 
 // flush flushes pending data from the buffered writer (c.bw) to the underlying
 // network connection, in case if a buffered writer is present.
-func (c *Conn) flush() {
+func (c *Conn) flush() error {
 	if c.bwPresent {
 		c.bwLock.Lock()
 		defer c.bwLock.Unlock()
 		if c.bw != nil {
-			c.bw.Flush()
+			c.conn.SetWriteDeadline(c.writeDeadline)
+			err := c.bw.Flush()
+			if err != nil {
+				c.writeErrMu.Lock()
+				if c.writeErr != nil {
+					c.writeErr = err
+				}
+				c.writeErrMu.Unlock()
+			}
+			return err
 		}
 	}
+	return nil
 }
 
 // LocalAddr returns the local network address.
@@ -534,27 +544,7 @@ func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) er
 		}
 	}
 
-	timer := time.NewTimer(d)
-	select {
-	case <-c.mu:
-		timer.Stop()
-	case <-timer.C:
-		return errWriteTimeout
-	}
-	defer func() { c.mu <- true }()
-
-	c.writeErrMu.Lock()
-	err := c.writeErr
-	c.writeErrMu.Unlock()
-	if err != nil {
-		return err
-	}
-
-	c.conn.SetWriteDeadline(deadline)
-	_, err = c.conn.Write(buf)
-	if err != nil {
-		return c.writeFatal(err)
-	}
+	err := c.write(messageType, deadline, buf, nil)
 	if messageType == CloseMessage {
 		c.writeFatal(ErrCloseSent)
 	}
@@ -1148,8 +1138,8 @@ func (r *messageReader) Close() error {
 // NEVER USE THIS. An untrusted peer could send an explosively compressed message. A megabyte of zeros can compress down to about 1kB. Always use NextReader() and kill the connection if you read too long a message.
 // ReadMessage() will error out immediately unless Conn.Unsafe is true.
 func (c *Conn) ReadMessage() (messageType int, p []byte, err error) {
-	if !c.Unsafe {
-		return noFrame, nil, errors.New("websocket: ReadMessage is not safe but Conn.Unsafe is not set")
+	if c.readLimit == 0 && !c.Unsafe {
+		return noFrame, nil, errors.New("websocket: ReadMessage() is not safe without SetReadLimit() and Conn.Unsafe is not set")
 	}
 	var r io.Reader
 	messageType, r, err = c.NextReader()

--- a/conn.go
+++ b/conn.go
@@ -385,7 +385,7 @@ func (c *Conn) flush() error {
 			err := c.bw.Flush()
 			if err != nil {
 				c.writeErrMu.Lock()
-				if c.writeErr != nil {
+				if c.writeErr == nil {
 					c.writeErr = err
 				}
 				c.writeErrMu.Unlock()
@@ -486,7 +486,7 @@ func (c *Conn) flushThread() {
 		err := c.bw.Flush()
 		if err != nil {
 			c.writeErrMu.Lock()
-			if c.writeErr != nil {
+			if c.writeErr == nil {
 				c.writeErr = err
 			}
 			c.writeErrMu.Unlock()


### PR DESCRIPTION
Fix Conn.WriteControl() to use the same underlying Conn.write() as regular messages so that it does buffering properly.
Add tests that WriteControl() and WriteMessage() can both correctly send a CloseMessage