### PR TITLE
Fix a leaky go-routine on server side connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ sudo: false
 
 matrix:
   include:
-    - go: 1.8.x
-    - go: 1.9.x
-    - go: 1.10.x
-    - go: 1.11.x
-    - go: 1.12.x
+    - go: 1.14.x
     - go: tip
   allow_failures:
     - go: tip

--- a/server.go
+++ b/server.go
@@ -240,7 +240,9 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 		netConn.SetWriteDeadline(time.Now().Add(u.HandshakeTimeout))
 	}
 	if _, err = netConn.Write(p); err != nil {
-		netConn.Close()
+		// we need to use our own connection object here since we need it to
+		// shut down the flush thread ( if there is one )
+		c.CloseWithoutFlush()
 		return nil, err
 	}
 	if u.HandshakeTimeout > 0 {


### PR DESCRIPTION
Fix a leaky go-routine on server side connections.
The `Upgrader.Upgrade` method in the `server.go` was not shutting down the connection cleanly when it had write errors right after the connection was established. This codepath is expected when a non-websocket aware client is trying to connect to the server.
Instead of calling the `CloseWithoutFlush`, the `Upgrader.Upgrade` method was closing the underlying network connection ( correctly ), and returning, potentially leaving the flush goroutine abandoned.